### PR TITLE
fix assignment to undeclared variable toolboxPath 

### DIFF
--- a/content/main/autocode/autocode.js
+++ b/content/main/autocode/autocode.js
@@ -54,7 +54,7 @@ if( ! window.autocode )
 				{
 					var devPath			= 'E:/05 - Commercial Projects/Komodo Extensions/AutoCode/tools/';
 					var toolbox			= ko.toolbox2.getExtensionToolbox("autocode@xjsfl.com");
-					toolboxPath			= toolbox ? (toolbox.path + '/').replace(/\\/g, '/') + '/' : devPath;
+					var toolboxPath		= toolbox ? (toolbox.path + '/').replace(/\\/g, '/') + '/' : devPath;
 					autocode.settings.toolboxPath = toolboxPath;
 					//alert(toolboxPath)
 				}


### PR DESCRIPTION
This was causing an error that was preventing subsequent widget code from running, preventing the Places pane from receiving it's widget class which in turn prevented it from being styled properly.
